### PR TITLE
Set the selector name as variable in the comment

### DIFF
--- a/lib/src/application/modules/ViewFactory.dart
+++ b/lib/src/application/modules/ViewFactory.dart
@@ -63,7 +63,7 @@ class ViewFactory {
         final dom.Element contentElement = dom.querySelector(selector);
 
         if(contentElement == null) {
-            _logger.severe('Please add <div id="main" class="mdl-content mdl-js-content">Loading...</div> to your index.html');
+            _logger.severe('Please add <div id="$selector" class="mdl-content mdl-js-content">Loading...</div> to your index.html');
             return;
         }
 


### PR DESCRIPTION
If the **selector** is set up in the viewFactory function as below, the log tell to add a "#main" ID, but I must rather add the selector I have filled in attributes of the function. In example for the example bellow the log must be :
`Please add <div id="cloud" class="mdl-content mdl-js-content">Loading...</div> to your index.html`

**Example of call with a selector :**

```
..addRoute(
    name: 'home',
    defaultRoute: true, path: '/',
    enter: view(
        "views/home.html",
        new mdl.DummyController(),
        __selector: "#cloud"__
    )
)
```
