### PR TITLE
Mistake in basic usage of Accordion

### DIFF
--- a/example/mdlx_accordion/web/index.html
+++ b/example/mdlx_accordion/web/index.html
@@ -91,7 +91,7 @@
 </div>
 <div class="demo-preview-block sample">
     <h5>Only one section is open</h5>
-    <div class="mdl-accordion-group mdl-accordion--radio-type mdl-js-ripple-effect">
+    <div class="mdl-accordion-group mdl-accordion--radio-type">
         <!-- Panel 1 -->
         <div class="mdl-accordion mdl-js-accordion mdl-js-ripple-effect">
             <label class="mdl-accordion__label"><i class="material-icons indicator">chevron_right</i>Panel 1</label>


### PR DESCRIPTION
Remove **mdl-js-ripple-effect** in div **mdl-accordion-group** for the example "Only one section is open"

If the class **mdl-js-ripple-effect** is set in the div **mdl-accordion-group**, then the first element of the accordion is rippling on each click, regardless of the element we click.

The code of the exemple is good, but the basic explanation has the mistake.
