### PR TITLE
Fix Dart Docs

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,8 +35,8 @@ dependencies:
 
   path: ^1.4.0
 
-  l10n: # ^0.17.0
-    path: /Volumes/Daten/DevLocal/DevDart/L10N4Dart
+  l10n: ^0.17.0
+    # path: /Volumes/Daten/DevLocal/DevDart/L10N4Dart
 
 dev_dependencies:
   test: any
@@ -44,8 +44,8 @@ dev_dependencies:
   material_icons: any
   grinder: any
   mdl_grinder:
-    # git: https://github.com/MikeMitterer/dart-mdl-grinder
-    path: /Volumes/Daten/DevLocal/DevDart/MaterialGrinder
+    git: https://github.com/MikeMitterer/dart-mdl-grinder
+    # path: /Volumes/Daten/DevLocal/DevDart/MaterialGrinder
 
 transformers:
 #  - di


### PR DESCRIPTION
Currently, Dart Docs for the latest version returns HTTP 404. This is due to not being able to find mdl_grinder, as per the [logs here](https://www.dartdocs.org/documentation/mdl/2.0.3/log.txt). This fix uses the github repo for mdl_grinder and l10n instead of the local path to the project. This fixes Dart docs generation, which consequently fixes [www.dartdocs.org](www.dartdocs.org).